### PR TITLE
[FEAT] ScreenUtils 보완 - 비율 프로퍼티 생성 (#30)

### DIFF
--- a/ACON-iOS/ACON-iOS/Application/SceneDelegate.swift
+++ b/ACON-iOS/ACON-iOS/Application/SceneDelegate.swift
@@ -17,8 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: windowScene)
         let navigationController = UINavigationController(rootViewController: LoginViewController())
         navigationController.navigationBar.isHidden = true
-//        self.window?.rootViewController = navigationController
-        self.window?.rootViewController = SpotListFilterViewController()
+        self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }
 

--- a/ACON-iOS/ACON-iOS/Global/Utils/ScreenUtils.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/ScreenUtils.swift
@@ -23,7 +23,7 @@ struct ScreenUtils {
     }
     
     
-    // MARK: - width 비율
+    // MARK: - 비율 프로퍼티
     
     static var widthRatio: CGFloat {
         let figmaWidth: CGFloat = 360

--- a/ACON-iOS/ACON-iOS/Global/Utils/ScreenUtils.swift
+++ b/ACON-iOS/ACON-iOS/Global/Utils/ScreenUtils.swift
@@ -22,4 +22,17 @@ struct ScreenUtils {
         return UIScreen.main.bounds.height
     }
     
+    
+    // MARK: - width 비율
+    
+    static var widthRatio: CGFloat {
+        let figmaWidth: CGFloat = 360
+        return width / figmaWidth
+    }
+    
+    static var heightRatio: CGFloat {
+        let figmaHeight: CGFloat = 780
+        return height / figmaHeight
+    }
+    
 }


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- feature/#30

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
제약조건을 설정할 때마다 아래처럼 `컴포넌트 높이 / 스크린 높이`로 비율을 일일이 계산해야 하는 불편함이 있었습니다.
```swift
$0.height.equalTo(ScreenUtils.height * 컴포넌트 높이 on figma / 스크린 높이 on figma)
```

제약조건을 좀 더 편하게 설정하고,
추후 피그마에서 사이즈가 변경되었을 때도 일괄 변경이 가능하도록 프로퍼티를 새롭게 생성했습니다.

### Usage
```swift
$0.height.equalTo(creenUtils.HeightRatio * 컴포넌트 높이 on figma)
```

## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #30
