### PR TITLE
[HOTFIX] 업로드 뷰 튕기는 오류 해결 (#74)

### DIFF
--- a/ACON-iOS/ACON-iOS/Presentation/TabBar/ACTabBarController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/TabBar/ACTabBarController.swift
@@ -16,6 +16,7 @@ class ACTabBarController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        delegate = self
         configureTabBarAppearance()
         setNavViewControllers()
     }
@@ -79,6 +80,26 @@ extension ACTabBarController {
         }
         
         return navViewController
+    }
+    
+}
+
+
+// MARK: - UITabBarControllerDelegate
+
+extension ACTabBarController: UITabBarControllerDelegate {
+    
+    func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        guard let viewControllers = viewControllers else { return true }
+        guard let index = viewControllers.firstIndex(of: viewController) else { return true }
+        
+        if index == ACTabBarItemType.allCases.firstIndex(of: .upload) {
+            let uploadVC = SpotUploadViewController()
+            uploadVC.modalPresentationStyle = .fullScreen
+            present(uploadVC, animated: true)
+            return false
+        }
+        return true
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
@@ -160,6 +160,7 @@ private extension DropAcornViewController {
             ACToastController.show(StringLiterals.Upload.noAcorn, bottomInset: 112, delayTime: 1)
             { [weak self] in return }
             dropAcornView.dropAcornLottieView.isHidden = true
+            disableLeaveReviewButton()
         } else {
             dropAcornView.dropAcornLottieView.isHidden = false
             toggleLottie(dropAcorn: dropAcorn)
@@ -174,10 +175,18 @@ private extension DropAcornViewController {
 
 private extension DropAcornViewController {
     
+    // TODO: - 나중에 전부 buttonConfiguration에 넣고 enable만 toggle
     func enableLeaveReviewButton() {
         dropAcornView.leaveReviewButton.do {
             $0.isEnabled = true
             $0.backgroundColor = .org0
+        }
+    }
+    
+    func disableLeaveReviewButton() {
+        dropAcornView.leaveReviewButton.do {
+            $0.isEnabled = false
+            $0.backgroundColor = .gray5
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
@@ -99,7 +99,10 @@ private extension DropAcornViewController {
         let data: ReviewPostModel = ReviewPostModel(spotID: spotID, acornCount: reviewAcornCount)
         // TODO: - 여기서 가는 로직은 임시적용 (VM init에서 true할 수 없음) -> 나중에 지우기
         let vc = ReviewFinishedViewController()
-        self.navigationController?.pushViewController(vc, animated: false)
+        vc.modalPresentationStyle = .fullScreen
+        present(vc, animated: false)
+//        let vc = ReviewFinishedViewController()
+//        self.navigationController?.pushViewController(vc, animated: false)
     }
     
     @objc

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/DropAcornViewController.swift
@@ -101,8 +101,6 @@ private extension DropAcornViewController {
         let vc = ReviewFinishedViewController()
         vc.modalPresentationStyle = .fullScreen
         present(vc, animated: false)
-//        let vc = ReviewFinishedViewController()
-//        self.navigationController?.pushViewController(vc, animated: false)
     }
     
     @objc

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/ReviewFinishedViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/ReviewFinishedViewController.swift
@@ -96,9 +96,11 @@ private extension ReviewFinishedViewController {
     
     @objc
     func closeView() {
-        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
-            sceneDelegate.window?.rootViewController = ACTabBarController()
+        var topController: UIViewController = self
+        while let presenting = topController.presentingViewController {
+            topController = presenting
         }
+        topController.dismiss(animated: true)
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotSearchViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotSearchViewController.swift
@@ -234,16 +234,7 @@ extension SpotSearchViewController: UICollectionViewDataSource {
 extension SpotSearchViewController: UITextFieldDelegate {
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        print("=== shouldChangeCharactersIn ===")
-        // TODO: - 여기 dismiss 시점 문제는 아닌 듯. 나중에 해결되면 지우기 🍠
-        // NOTE: - 텍스트필드 / 키보드 문제도 아님. 키보드 전체 isHidden 처리해도 같은 문제 발생 🍠
-//        guard !isBeingDismissed else { return false }
-//        guard presentingViewController != nil else {
-//            print("===== ViewController is being dismissed =====")
-//            return false
-//        }
         acDebouncer.call { [weak self] in
-//            guard let self = self, !self.isBeingDismissed else { return }
             self?.updateSearchKeyword(textField.text ?? "")
         }
         return true

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotUploadViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotUploadViewController.swift
@@ -31,8 +31,6 @@ class SpotUploadViewController: BaseNavViewController {
     
     var longitude: Double = 0
     
-    // NOTE: isModalPresenting, isLocationUpdated으로 플래그 검증 시도해봤으나, 유무 상관없이 튕김 🍠
-    
     
     // MARK: - LifeCycle
     
@@ -129,18 +127,6 @@ private extension SpotUploadViewController {
         let vc = DropAcornViewController(spotID: selectedSpotID)
         vc.modalPresentationStyle = .fullScreen
         present(vc, animated: false)
-//        // 현재 화면을 dismiss하고 바로 네비게이션을 present
-//        self.dismiss(animated: true) { [weak self] in
-//            self?.tabBarController?.present(navigationController, animated: false)
-//        }
-//        TODO: - 🍠 딱히 이거의 타이밍 시점도 아닌 것 같음 -> 해결되면 지우기
-//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-//            guard let self = self else { return }
-//            let vc = DropAcornViewController(spotID: selectedSpotID)
-//            self.navigationController?.pushViewController(vc, animated: false)
-//        }
-//        let vc = DropAcornViewController(spotID: selectedSpotID)
-//        navigationController?.pushViewController(vc, animated: false)
     }
     
     @objc
@@ -174,32 +160,14 @@ extension SpotUploadViewController: ACLocationManagerDelegate {
 extension SpotUploadViewController {
     
     func setSpotSearchModal() {
-        print("===== setSpotSearchModal 시작 =====")
-        // TODO: - 🍠 이미 모달이 표시되어있는 문제도 아닌 듯. 해결되면 지울 것
-//        print("isModalPresenting", isModalPresenting)
-//        if presentedViewController == nil {
-//            isModalPresenting = false  // 실제로 표시된 모달이 없으면 강제로 false로 리셋
-//        }
-//        guard !isModalPresenting else { return }  // 이미 모달이 표시중이면 리턴
-        presentSpotSearchModal()
-    }
-    
-    func presentSpotSearchModal() {
-        print("===== presentSpotSearchModal 시작 =====")
-
         let vc = SpotSearchViewController()
-        // TODO: 🍠 메인 스레드 업데이트도 딱히 의미없어보임. 해결되면 걍 없이 ㄱㄱ할 것
-        // NOTE: - 튕기는 시점도 제각각 🍠
-        // NOTE: - 정상 프로세스와 튕기는 프로세스의 콘솔이 아예 일치할 때도 있음...🍠
         vc.dismissCompletion = { [weak self] in
-            print("===== dismissCompletion 호출 =====")
             DispatchQueue.main.async {
                 self?.removeBlurView()
             }
         }
         
         vc.completionHandler = { [weak self] selectedSpotID, selectedSpotName in
-            print("===== completionHandler 호출 =====")
             guard let self = self else { return }
             self.selectedSpotID = selectedSpotID
             
@@ -227,10 +195,8 @@ extension SpotUploadViewController {
             guard let self = self else { return }
             self.addBlurView()
             vc.setLongSheetLayout()
-            self.present(vc, animated: true) {
-                print("===== present 완료 =====")
-            }
+            self.present(vc, animated: true)
         }
     }
-
+    
 }

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotUploadViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotUploadViewController.swift
@@ -142,8 +142,6 @@ extension SpotUploadViewController: ACLocationManagerDelegate {
     func locationManager(_ manager: ACLocationManager, didUpdateLocation coordinate: CLLocationCoordinate2D) {
         // TODO: - 연관검색어 네트워크 요청 - 여기 아니면 spotSearch viewWillAppear
 
-        manager.stopUpdatingLocation()
-        manager.removeDelegate(self)
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             

--- a/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotUploadViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/Upload/View/SpotUploadViewController.swift
@@ -126,14 +126,21 @@ private extension SpotUploadViewController {
     
     @objc
     func dropAcornButtonTapped() {
+        let vc = DropAcornViewController(spotID: selectedSpotID)
+        vc.modalPresentationStyle = .fullScreen
+        present(vc, animated: false)
+//        // 현재 화면을 dismiss하고 바로 네비게이션을 present
+//        self.dismiss(animated: true) { [weak self] in
+//            self?.tabBarController?.present(navigationController, animated: false)
+//        }
 //        TODO: - 🍠 딱히 이거의 타이밍 시점도 아닌 것 같음 -> 해결되면 지우기
 //        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
 //            guard let self = self else { return }
 //            let vc = DropAcornViewController(spotID: selectedSpotID)
 //            self.navigationController?.pushViewController(vc, animated: false)
 //        }
-        let vc = DropAcornViewController(spotID: selectedSpotID)
-        navigationController?.pushViewController(vc, animated: false)
+//        let vc = DropAcornViewController(spotID: selectedSpotID)
+//        navigationController?.pushViewController(vc, animated: false)
     }
     
     @objc


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #74

## 🥔 **작업 내용**
업로드 뷰에 두 번째로 들어갈 때 튕기는 오류를 해결했습니다.

## 🚨 참고 사항
지석오빠가 말한 대로 ACTabVC()에서 네비게이션으로 업로드 뷰를 띄우는 거 자체가 문제였어서, 모든 업로드 프로세스의 뷰를 모달로 변경하였습니다. 
시간이 없어 ACTabVC에서 업로드 프로세스 관련 코드를 지우진 않고, 그냥 모달로 설정하는 델리게이트만 추가해놨어요 !
추후 ACTabVC() 코드 전면 수정하겠습니다 ~~

## 📸 스크린샷

## 💥 To be sure
- [ ] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #74
