### PR TITLE
[FEAT] 장소 상세 네트워크 연결 (#85)

### DIFF
--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		7462617F2D3F9F1400A4E84F /* GetSpotDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */; };
 		746261832D3F9FD900A4E84F /* GetSpotMenuResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746261822D3F9FC600A4E84F /* GetSpotMenuResponse.swift */; };
 		746261852D3FA0A400A4E84F /* PostGuidedSpotRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746261842D3FA08F00A4E84F /* PostGuidedSpotRequest.swift */; };
+		746261892D3FA29C00A4E84F /* SpotDetailTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746261882D3FA29400A4E84F /* SpotDetailTargetType.swift */; };
 		746F39822D342523003F8498 /* SheetUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746F39812D342520003F8498 /* SheetUtils.swift */; };
 		746FF3C02D3D8669001CDAAC /* ACWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */; };
 		747F4FC12D3DC80B003DECBF /* finishedUpload.json in Resources */ = {isa = PBXBuildFile; fileRef = 747F4FC02D3DC80B003DECBF /* finishedUpload.json */; };
@@ -209,6 +210,7 @@
 		7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSpotDetailResponse.swift; sourceTree = "<group>"; };
 		746261822D3F9FC600A4E84F /* GetSpotMenuResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSpotMenuResponse.swift; sourceTree = "<group>"; };
 		746261842D3FA08F00A4E84F /* PostGuidedSpotRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostGuidedSpotRequest.swift; sourceTree = "<group>"; };
+		746261882D3FA29400A4E84F /* SpotDetailTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotDetailTargetType.swift; sourceTree = "<group>"; };
 		746F39812D342520003F8498 /* SheetUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetUtils.swift; sourceTree = "<group>"; };
 		746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACWebViewController.swift; sourceTree = "<group>"; };
 		747F4FC02D3DC80B003DECBF /* finishedUpload.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = finishedUpload.json; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 			isa = PBXGroup;
 			children = (
 				7462617D2D3F9E9D00A4E84F /* DTO */,
+				746261882D3FA29400A4E84F /* SpotDetailTargetType.swift */,
 			);
 			path = SpotDetail;
 			sourceTree = "<group>";
@@ -1235,6 +1238,7 @@
 				1547A88B2D3596B600E96616 /* SpotType.swift in Sources */,
 				74BF92172D393B4A00B923E3 /* Int+.swift in Sources */,
 				748ECA6E2D3196F100BBC981 /* LoginViewController.swift in Sources */,
+				746261892D3FA29C00A4E84F /* SpotDetailTargetType.swift in Sources */,
 				D6E34C432D398B6000CEFA04 /* CustomAlertImageViewController.swift in Sources */,
 				741E68952D3D38BC00DF99EF /* BaseService.swift in Sources */,
 				D6E34C462D398B6000CEFA04 /* AlertType.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		7462615E2D3E5B6D00A4E84F /* drop2Acorn.json in Resources */ = {isa = PBXBuildFile; fileRef = 746261572D3E5B6D00A4E84F /* drop2Acorn.json */; };
 		7462615F2D3E5B6D00A4E84F /* drop3Acorn.json in Resources */ = {isa = PBXBuildFile; fileRef = 746261582D3E5B6D00A4E84F /* drop3Acorn.json */; };
 		7462617F2D3F9F1400A4E84F /* GetSpotDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */; };
+		746261832D3F9FD900A4E84F /* GetSpotMenuResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746261822D3F9FC600A4E84F /* GetSpotMenuResponse.swift */; };
 		746F39822D342523003F8498 /* SheetUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746F39812D342520003F8498 /* SheetUtils.swift */; };
 		746FF3C02D3D8669001CDAAC /* ACWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */; };
 		747F4FC12D3DC80B003DECBF /* finishedUpload.json in Resources */ = {isa = PBXBuildFile; fileRef = 747F4FC02D3DC80B003DECBF /* finishedUpload.json */; };
@@ -205,6 +206,7 @@
 		746261592D3E5B6D00A4E84F /* drop4Acorn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = drop4Acorn.json; sourceTree = "<group>"; };
 		7462615A2D3E5B6D00A4E84F /* drop5Acorn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = drop5Acorn.json; sourceTree = "<group>"; };
 		7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSpotDetailResponse.swift; sourceTree = "<group>"; };
+		746261822D3F9FC600A4E84F /* GetSpotMenuResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSpotMenuResponse.swift; sourceTree = "<group>"; };
 		746F39812D342520003F8498 /* SheetUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetUtils.swift; sourceTree = "<group>"; };
 		746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACWebViewController.swift; sourceTree = "<group>"; };
 		747F4FC02D3DC80B003DECBF /* finishedUpload.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = finishedUpload.json; sourceTree = "<group>"; };
@@ -570,6 +572,7 @@
 		7462617D2D3F9E9D00A4E84F /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				746261822D3F9FC600A4E84F /* GetSpotMenuResponse.swift */,
 				7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */,
 			);
 			path = DTO;
@@ -1218,6 +1221,7 @@
 				D6978F542D37B29100523A25 /* OnboardingMapping.swift in Sources */,
 				D6D0F51F2D36BAFE00326F17 /* OnboardingViewController.swift in Sources */,
 				744BAF172D300AB900F95B4A /* DummyComponent.swift in Sources */,
+				746261832D3F9FD900A4E84F /* GetSpotMenuResponse.swift in Sources */,
 				741E689A2D3D43FF00DF99EF /* EmptyResponse.swift in Sources */,
 				15CD256E2D3D795800320006 /* FloatingButton.swift in Sources */,
 				D696F1B62D3A83D600CCD5FF /* CustomAlertImageView.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -557,6 +557,21 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		7462617C2D3F9E9400A4E84F /* SpotDetail */ = {
+			isa = PBXGroup;
+			children = (
+				7462617D2D3F9E9D00A4E84F /* DTO */,
+			);
+			path = SpotDetail;
+			sourceTree = "<group>";
+		};
+		7462617D2D3F9E9D00A4E84F /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
 		748D6F682D2BCA1C007690B4 /* ACON-iOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -600,6 +615,7 @@
 		748D6F712D2BCA7E007690B4 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				7462617C2D3F9E9400A4E84F /* SpotDetail */,
 				741E68A32D3D616200DF99EF /* Test */,
 				743069872D3D2EDA0033178C /* Base */,
 			);

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		7462615D2D3E5B6D00A4E84F /* drop4Acorn.json in Resources */ = {isa = PBXBuildFile; fileRef = 746261592D3E5B6D00A4E84F /* drop4Acorn.json */; };
 		7462615E2D3E5B6D00A4E84F /* drop2Acorn.json in Resources */ = {isa = PBXBuildFile; fileRef = 746261572D3E5B6D00A4E84F /* drop2Acorn.json */; };
 		7462615F2D3E5B6D00A4E84F /* drop3Acorn.json in Resources */ = {isa = PBXBuildFile; fileRef = 746261582D3E5B6D00A4E84F /* drop3Acorn.json */; };
+		7462617F2D3F9F1400A4E84F /* GetSpotDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */; };
 		746F39822D342523003F8498 /* SheetUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746F39812D342520003F8498 /* SheetUtils.swift */; };
 		746FF3C02D3D8669001CDAAC /* ACWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */; };
 		747F4FC12D3DC80B003DECBF /* finishedUpload.json in Resources */ = {isa = PBXBuildFile; fileRef = 747F4FC02D3DC80B003DECBF /* finishedUpload.json */; };
@@ -203,6 +204,7 @@
 		746261582D3E5B6D00A4E84F /* drop3Acorn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = drop3Acorn.json; sourceTree = "<group>"; };
 		746261592D3E5B6D00A4E84F /* drop4Acorn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = drop4Acorn.json; sourceTree = "<group>"; };
 		7462615A2D3E5B6D00A4E84F /* drop5Acorn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = drop5Acorn.json; sourceTree = "<group>"; };
+		7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSpotDetailResponse.swift; sourceTree = "<group>"; };
 		746F39812D342520003F8498 /* SheetUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetUtils.swift; sourceTree = "<group>"; };
 		746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACWebViewController.swift; sourceTree = "<group>"; };
 		747F4FC02D3DC80B003DECBF /* finishedUpload.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = finishedUpload.json; sourceTree = "<group>"; };
@@ -568,6 +570,7 @@
 		7462617D2D3F9E9D00A4E84F /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -1139,6 +1142,7 @@
 				748D6F692D2BCA1C007690B4 /* AppDelegate.swift in Sources */,
 				74054ECE2D32549F00D1CDE4 /* ACLocationManager.swift in Sources */,
 				749A01032D3A6E0100CD7A90 /* ACDebouncer.swift in Sources */,
+				7462617F2D3F9F1400A4E84F /* GetSpotDetailResponse.swift in Sources */,
 				745C7E0D2D35A04A0074DBDB /* SearchKeywordCollectionViewCell.swift in Sources */,
 				748D6FA62D2C3F44007690B4 /* BaseView.swift in Sources */,
 				74220DD62D3436C2000684BF /* SpotUploadView.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		7462615F2D3E5B6D00A4E84F /* drop3Acorn.json in Resources */ = {isa = PBXBuildFile; fileRef = 746261582D3E5B6D00A4E84F /* drop3Acorn.json */; };
 		7462617F2D3F9F1400A4E84F /* GetSpotDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */; };
 		746261832D3F9FD900A4E84F /* GetSpotMenuResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746261822D3F9FC600A4E84F /* GetSpotMenuResponse.swift */; };
+		746261852D3FA0A400A4E84F /* PostGuidedSpotRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746261842D3FA08F00A4E84F /* PostGuidedSpotRequest.swift */; };
 		746F39822D342523003F8498 /* SheetUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746F39812D342520003F8498 /* SheetUtils.swift */; };
 		746FF3C02D3D8669001CDAAC /* ACWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */; };
 		747F4FC12D3DC80B003DECBF /* finishedUpload.json in Resources */ = {isa = PBXBuildFile; fileRef = 747F4FC02D3DC80B003DECBF /* finishedUpload.json */; };
@@ -207,6 +208,7 @@
 		7462615A2D3E5B6D00A4E84F /* drop5Acorn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = drop5Acorn.json; sourceTree = "<group>"; };
 		7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSpotDetailResponse.swift; sourceTree = "<group>"; };
 		746261822D3F9FC600A4E84F /* GetSpotMenuResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSpotMenuResponse.swift; sourceTree = "<group>"; };
+		746261842D3FA08F00A4E84F /* PostGuidedSpotRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostGuidedSpotRequest.swift; sourceTree = "<group>"; };
 		746F39812D342520003F8498 /* SheetUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetUtils.swift; sourceTree = "<group>"; };
 		746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACWebViewController.swift; sourceTree = "<group>"; };
 		747F4FC02D3DC80B003DECBF /* finishedUpload.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = finishedUpload.json; sourceTree = "<group>"; };
@@ -572,6 +574,7 @@
 		7462617D2D3F9E9D00A4E84F /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				746261842D3FA08F00A4E84F /* PostGuidedSpotRequest.swift */,
 				746261822D3F9FC600A4E84F /* GetSpotMenuResponse.swift */,
 				7462617E2D3F9F0300A4E84F /* GetSpotDetailResponse.swift */,
 			);
@@ -1135,6 +1138,7 @@
 				741E68912D3D385A00DF99EF /* ACPlugin.swift in Sources */,
 				74BF92272D39957600B923E3 /* StickyHeaderView.swift in Sources */,
 				1517FD7F2D3961A800638173 /* CustomSlider.swift in Sources */,
+				746261852D3FA0A400A4E84F /* PostGuidedSpotRequest.swift in Sources */,
 				741E68982D3D3D8E00DF99EF /* ErrorResponse.swift in Sources */,
 				748D6F822D2BCDB3007690B4 /* ScreenUtils.swift in Sources */,
 				741E68AC2D3D6DA800DF99EF /* HeaderType.swift in Sources */,

--- a/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
+++ b/ACON-iOS/ACON-iOS.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		746261832D3F9FD900A4E84F /* GetSpotMenuResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746261822D3F9FC600A4E84F /* GetSpotMenuResponse.swift */; };
 		746261852D3FA0A400A4E84F /* PostGuidedSpotRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746261842D3FA08F00A4E84F /* PostGuidedSpotRequest.swift */; };
 		746261892D3FA29C00A4E84F /* SpotDetailTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746261882D3FA29400A4E84F /* SpotDetailTargetType.swift */; };
+		7462618B2D3FA4A800A4E84F /* SpotDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7462618A2D3FA4A200A4E84F /* SpotDetailService.swift */; };
 		746F39822D342523003F8498 /* SheetUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746F39812D342520003F8498 /* SheetUtils.swift */; };
 		746FF3C02D3D8669001CDAAC /* ACWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */; };
 		747F4FC12D3DC80B003DECBF /* finishedUpload.json in Resources */ = {isa = PBXBuildFile; fileRef = 747F4FC02D3DC80B003DECBF /* finishedUpload.json */; };
@@ -211,6 +212,7 @@
 		746261822D3F9FC600A4E84F /* GetSpotMenuResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSpotMenuResponse.swift; sourceTree = "<group>"; };
 		746261842D3FA08F00A4E84F /* PostGuidedSpotRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostGuidedSpotRequest.swift; sourceTree = "<group>"; };
 		746261882D3FA29400A4E84F /* SpotDetailTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotDetailTargetType.swift; sourceTree = "<group>"; };
+		7462618A2D3FA4A200A4E84F /* SpotDetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotDetailService.swift; sourceTree = "<group>"; };
 		746F39812D342520003F8498 /* SheetUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetUtils.swift; sourceTree = "<group>"; };
 		746FF3BF2D3D8662001CDAAC /* ACWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACWebViewController.swift; sourceTree = "<group>"; };
 		747F4FC02D3DC80B003DECBF /* finishedUpload.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = finishedUpload.json; sourceTree = "<group>"; };
@@ -570,6 +572,7 @@
 			children = (
 				7462617D2D3F9E9D00A4E84F /* DTO */,
 				746261882D3FA29400A4E84F /* SpotDetailTargetType.swift */,
+				7462618A2D3FA4A200A4E84F /* SpotDetailService.swift */,
 			);
 			path = SpotDetail;
 			sourceTree = "<group>";
@@ -1234,6 +1237,7 @@
 				D696F1B62D3A83D600CCD5FF /* CustomAlertImageView.swift in Sources */,
 				741A06CA2D35415800778219 /* DropAcornViewController.swift in Sources */,
 				15A3F6A62D36C49F00577E16 /* SpotListItemSizeType.swift in Sources */,
+				7462618B2D3FA4A800A4E84F /* SpotDetailService.swift in Sources */,
 				748D6F992D2BD54E007690B4 /* DummyProtocol.swift in Sources */,
 				1547A88B2D3596B600E96616 /* SpotType.swift in Sources */,
 				74BF92172D393B4A00B923E3 /* Int+.swift in Sources */,

--- a/ACON-iOS/ACON-iOS/Network/Base/ACService.swift
+++ b/ACON-iOS/ACON-iOS/Network/Base/ACService.swift
@@ -19,4 +19,6 @@ final class ACService {
     
 //    lazy var authService: AuthService = AuthService()
     
+    lazy var spotDetailService: SpotDetailService = SpotDetailService()
+    
 }

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotDetailResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotDetailResponse.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 struct GetSpotDetailResponse: Codable {
     
     let id: Int64

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotDetailResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotDetailResponse.swift
@@ -1,0 +1,31 @@
+//
+//  GetSpotDetailResponse.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 1/21/25.
+//
+
+import Foundation
+
+
+struct GetSpotDetailResponse: Codable {
+    
+    let id: Int64
+    
+    let name: String
+    
+    let spotType: String
+    
+    let imageList: [String]
+    
+    let openStatus: Bool
+
+    let localAcornCount: Int
+    
+    let basicAcornCount: Int
+    
+    let latitude: Double
+    
+    let longitude: Double
+    
+}

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotDetailResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotDetailResponse.swift
@@ -18,6 +18,8 @@ struct GetSpotDetailResponse: Codable {
     let imageList: [String]
     
     let openStatus: Bool
+    
+    let address: String
 
     let localAcornCount: Int
     

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotMenuResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotMenuResponse.swift
@@ -21,6 +21,6 @@ struct SpotMenuInfo: Codable {
     
     let price: Int
     
-    let image: String
+    let image: String?
     
 }

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotMenuResponse.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/GetSpotMenuResponse.swift
@@ -1,0 +1,26 @@
+//
+//  GetSpotMenuResponse.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 1/21/25.
+//
+
+import Foundation
+
+struct GetSpotMenuResponse: Codable {
+    
+    let menuList: [SpotMenuInfo]
+    
+}
+
+struct SpotMenuInfo: Codable {
+    
+    let id: Int64
+    
+    let name: String
+    
+    let price: Int
+    
+    let image: String
+    
+}

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/PostGuidedSpotRequest.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/DTO/PostGuidedSpotRequest.swift
@@ -1,0 +1,14 @@
+//
+//  PostGuidedSpotRequest.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 1/21/25.
+//
+
+import Foundation
+
+struct PostGuidedSpotRequest: Codable {
+    
+    let spotId: Int64
+    
+}

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailService.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailService.swift
@@ -1,0 +1,64 @@
+//
+//  SpotDetailService.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 1/21/25.
+//
+
+import Foundation
+
+import Moya
+
+protocol SpotDetailServiceProtocol {
+    
+    func getSpotDetail(spotID: Int64,
+                       completion: @escaping (NetworkResult<GetSpotDetailResponse>) -> Void)
+    func getSpotMenu(spotID: Int64,
+                     completion: @escaping (NetworkResult<GetSpotMenuResponse>) -> Void)
+    func postGuidedSpot(requestBody: PostGuidedSpotRequest,
+                        completion: @escaping (NetworkResult<EmptyResponse>) -> Void)
+    
+}
+
+final class SpotDetailService: BaseService<SpotDetailTargetType>,
+                               SpotDetailServiceProtocol {
+    
+    func getSpotDetail(spotID: Int64, completion: @escaping (NetworkResult<GetSpotDetailResponse>) -> Void) {
+        self.provider.request(.getSpotDetail(spotID: spotID)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<GetSpotDetailResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data, type: GetSpotDetailResponse.self)
+                completion(networkResult)
+            case .failure(let errorResponse):
+                print(errorResponse)
+            }
+        }
+    }
+    
+    func getSpotMenu(spotID: Int64,
+                     completion: @escaping (NetworkResult<GetSpotMenuResponse>) -> Void) {
+        self.provider.request(.getSpotMenu(spotID: spotID)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<GetSpotMenuResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data, type: GetSpotMenuResponse.self)
+                completion(networkResult)
+            case .failure(let errorResponse):
+                print(errorResponse)
+            }
+        }
+    }
+
+    func postGuidedSpot(requestBody: PostGuidedSpotRequest,
+                        completion: @escaping (NetworkResult<EmptyResponse>) -> Void) {
+        self.provider.request(.postGuidedSpot) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<EmptyResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data, type: EmptyResponse.self)
+                completion(networkResult)
+            case .failure(let errorResponse):
+                print(errorResponse)
+            }
+        }
+    }
+    
+}

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailService.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailService.swift
@@ -50,7 +50,7 @@ final class SpotDetailService: BaseService<SpotDetailTargetType>,
 
     func postGuidedSpot(requestBody: PostGuidedSpotRequest,
                         completion: @escaping (NetworkResult<EmptyResponse>) -> Void) {
-        self.provider.request(.postGuidedSpot) { result in
+        self.provider.request(.postGuidedSpot(requestBody)) { result in
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<EmptyResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data, type: EmptyResponse.self)

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
@@ -1,0 +1,61 @@
+//
+//  SpotDetailTargetType.swift
+//  ACON-iOS
+//
+//  Created by 이수민 on 1/21/25.
+//
+
+import Foundation
+
+import Moya
+
+enum SpotDetailTargetType {
+    
+    case getSpotDetail(spotID: Int64)
+    case getSpotMenu(spotID: Int64)
+    case postGuidedSpot
+    
+}
+
+extension SpotDetailTargetType: TargetType {
+
+    var method: Moya.Method {
+        switch self {
+        case .postGuidedSpot:
+            return .post
+        default:
+            return .get
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .getSpotDetail(let spotID):
+            return utilPath + "spot/\(spotID)"
+        case .getSpotMenu(let spotID):
+            return utilPath + "spot/\(spotID)/menus"
+        case .postGuidedSpot:
+            return utilPath + "member/guided-spot"
+        }
+    }
+    
+    var task: Task {
+        return .requestPlain
+    }
+    
+    var headers: [String : String]? {
+        var headers = HeaderType.noHeader
+        switch self {
+        case .getSpotDetail:
+            headers = HeaderType.basicHeader
+        case .getSpotMenu:
+            headers = HeaderType.noHeader
+        case .postGuidedSpot:
+            let token = UserDefaults.standard.string(forKey: StringLiterals.Network.accessToken) ?? ""
+            headers = HeaderType.headerWithToken(token: "Bearer " + token)
+        }
+        return headers
+    }
+    
+}
+

--- a/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
+++ b/ACON-iOS/ACON-iOS/Network/SpotDetail/SpotDetailTargetType.swift
@@ -13,7 +13,7 @@ enum SpotDetailTargetType {
     
     case getSpotDetail(spotID: Int64)
     case getSpotMenu(spotID: Int64)
-    case postGuidedSpot
+    case postGuidedSpot(_ requestBody: PostGuidedSpotRequest)
     
 }
 
@@ -40,7 +40,12 @@ extension SpotDetailTargetType: TargetType {
     }
     
     var task: Task {
-        return .requestPlain
+        switch self {
+        case .postGuidedSpot(let requestBody):
+            return .requestJSONEncodable(requestBody)
+        default:
+            return .requestPlain
+        }
     }
     
     var headers: [String : String]? {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/Model/SpotDetailModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/Model/SpotDetailModel.swift
@@ -10,7 +10,7 @@ import UIKit
 
 struct SpotDetailInfoModel: Equatable {
     
-    let spotID: Int
+    let spotID: Int64
     
     let name: String
     
@@ -30,7 +30,7 @@ struct SpotDetailInfoModel: Equatable {
     
     let longitude: Double
     
-    init(spotID: Int,
+    init(spotID: Int64,
          name: String,
          spotType: String,
          firstImageURL: String,

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/Model/SpotDetailModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/Model/SpotDetailModel.swift
@@ -57,7 +57,7 @@ struct SpotDetailInfoModel: Equatable {
 
 struct SpotMenuModel: Equatable {
     
-    let menuID: Int
+    let menuID: Int64
     
     let name: String
     
@@ -65,7 +65,7 @@ struct SpotMenuModel: Equatable {
     
     let imageURL: String
     
-    init(menuID: Int, name: String, price: Int, imageURL: String) {
+    init(menuID: Int64, name: String, price: Int, imageURL: String) {
         self.menuID = menuID
         self.name = name
         self.price = price

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/Model/SpotDetailModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/Model/SpotDetailModel.swift
@@ -63,9 +63,9 @@ struct SpotMenuModel: Equatable {
     
     let price: Int
     
-    let imageURL: String
+    let imageURL: String?
     
-    init(menuID: Int64, name: String, price: Int, imageURL: String) {
+    init(menuID: Int64, name: String, price: Int, imageURL: String?) {
         self.menuID = menuID
         self.name = name
         self.price = price

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Cell/MenuCollectionViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Cell/MenuCollectionViewCell.swift
@@ -58,7 +58,8 @@ final class MenuCollectionViewCell: BaseCollectionViewCell {
         
         self.backgroundColor = .clear
         menuImageView.do {
-//            $0.image = .imgStoreDetailMenulist
+            $0.layer.cornerRadius = 6
+            $0.clipsToBounds = true
             $0.contentMode = .scaleAspectFill
         }
     }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Cell/MenuCollectionViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/Cell/MenuCollectionViewCell.swift
@@ -67,12 +67,13 @@ final class MenuCollectionViewCell: BaseCollectionViewCell {
 
 extension MenuCollectionViewCell {
     
-    func dataBind(_ menuInfoData: SpotMenuModel, _ indexRow: Int) {
-        // TODO: imageView kf - 없으면 넣지 말기
-        menuNameLabel.setLabel(text: menuInfoData.name,
+    func dataBind(_ data: SpotMenuModel, _ indexRow: Int) {
+        if let imageURL = data.imageURL {
+            menuImageView.kf.setImage(with: URL(string: imageURL), options: [.transition(.none), .cacheOriginalImage])
+        }
+        menuNameLabel.setLabel(text: data.name,
                                style: .b2)
-        // TODO: 가격 쉼표 넣기
-        menuPriceLabel.setLabel(text: menuInfoData.price.formattedWithSeparator + "원",
+        menuPriceLabel.setLabel(text: data.price.formattedWithSeparator + "원",
                                style: .s1)
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailView.swift
@@ -215,6 +215,7 @@ final class SpotDetailView: BaseView {
                                                                     trailing: 10)
             $0.setAttributedTitle(text: StringLiterals.SpotDetail.isOpen, style: .b4)
             $0.configuration?.background.strokeWidth = 0
+            $0.isUserInteractionEnabled = false
         }
         
         addressImageView.do {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import SnapKit
 import Then
 
@@ -255,6 +256,7 @@ final class SpotDetailView: BaseView {
 extension SpotDetailView {
     
     func bindData(data: SpotDetailInfoModel) {
+        self.spotDetailImageView.kf.setImage(with: URL(string: data.firstImageURL), options: [.transition(.none),.cacheOriginalImage])
         let openStatus = data.openStatus
         self.openStatusButton.isSelected = openStatus
         self.openStatusButton.setAttributedTitle(

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
@@ -108,6 +108,7 @@ private extension SpotDetailViewController {
     
     @objc
     func findCourseButtonTapped() {
+        spotDetailViewModel.postGuidedSpot()
         spotDetailViewModel.redirectToNaverMap()
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
@@ -41,6 +41,7 @@ class SpotDetailViewController: BaseNavViewController, UICollectionViewDelegate 
         super.viewWillAppear(false)
 
         spotDetailViewModel.getSpotDetail()
+        spotDetailViewModel.getSpotMenu()
     }
     
     override func setHierarchy() {
@@ -87,6 +88,13 @@ private extension SpotDetailViewController {
             if onSuccess {
                 self?.bindNavBar(data: data)
                 self?.spotDetailView.bindData(data: data)
+            }
+        }
+        
+        self.spotDetailViewModel.onSuccessGetSpotMenu.bind { [weak self] onSuccess in
+            guard let onSuccess, let data = self?.spotDetailViewModel.spotMenu.value else { return }
+            if onSuccess {
+                self?.spotDetailView.menuCollectionView.reloadData()
             }
         }
         
@@ -138,9 +146,9 @@ private extension SpotDetailViewController {
     }
     
     func updateCollectionViewHeight() {
-        let numberOfItems = spotDetailViewModel.menuDummyData.count
+        let numberOfItems = spotDetailViewModel.spotMenu.value?.count
         let itemHeight = SpotDetailView.menuCollectionViewFlowLayout.itemSize.height
-        let totalHeight = itemHeight * CGFloat(numberOfItems)
+        let totalHeight = itemHeight * CGFloat(numberOfItems ?? 0)
         
         spotDetailView.menuCollectionView.snp.updateConstraints {
             $0.height.equalTo(totalHeight)
@@ -161,7 +169,7 @@ extension SpotDetailViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let data = spotDetailViewModel.menuDummyData[indexPath.item]
+        guard let data = spotDetailViewModel.spotMenu.value?[indexPath.item] else { return UICollectionViewCell() }
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MenuCollectionViewCell.cellIdentifier, for: indexPath) as? MenuCollectionViewCell else {
             return UICollectionViewCell() }
         cell.dataBind(data, indexPath.item)

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
@@ -19,7 +19,8 @@ class SpotDetailViewController: BaseNavViewController, UICollectionViewDelegate 
 
     // MARK: - Properties
     
-    private let spotDetailViewModel = SpotDetailViewModel()
+    // TODO: - 이거 spotID 전 화면에서 넘겨받는 것으로 변경
+    private let spotDetailViewModel = SpotDetailViewModel(spotID: 1)
     
     private let spotDetailName: String = "가게명가게명"
     
@@ -33,6 +34,13 @@ class SpotDetailViewController: BaseNavViewController, UICollectionViewDelegate 
         addTarget()
         registerCell()
         setDelegate()
+        bindViewModel()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(false)
+
+        spotDetailViewModel.getSpotDetail()
     }
     
     override func setHierarchy() {
@@ -55,8 +63,6 @@ class SpotDetailViewController: BaseNavViewController, UICollectionViewDelegate 
         self.applyGlassmorphism()
         self.setBackButton()
         updateCollectionViewHeight()
-        bindNavBar(data: spotDetailViewModel.spotDetailDummyData)
-        spotDetailView.bindData(data: spotDetailViewModel.spotDetailDummyData)
     }
     
     private func addTarget() {
@@ -70,6 +76,23 @@ class SpotDetailViewController: BaseNavViewController, UICollectionViewDelegate 
 
 }
 
+
+// MARK: - bindViewModel
+
+private extension SpotDetailViewController {
+    
+    func bindViewModel() {
+        self.spotDetailViewModel.onSuccessGetSpotDetail.bind { [weak self] onSuccess in
+            guard let onSuccess, let data = self?.spotDetailViewModel.spotDetail.value else { return }
+            if onSuccess {
+                self?.bindNavBar(data: data)
+                self?.spotDetailView.bindData(data: data)
+            }
+        }
+        
+    }
+    
+}
 
 // MARK: - @objc methods
 

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/View/SpotDetailViewController.swift
@@ -63,7 +63,6 @@ class SpotDetailViewController: BaseNavViewController, UICollectionViewDelegate 
         
         self.applyGlassmorphism()
         self.setBackButton()
-        updateCollectionViewHeight()
     }
     
     private func addTarget() {
@@ -95,6 +94,7 @@ private extension SpotDetailViewController {
             guard let onSuccess, let data = self?.spotDetailViewModel.spotMenu.value else { return }
             if onSuccess {
                 self?.spotDetailView.menuCollectionView.reloadData()
+                self?.updateCollectionViewHeight()
             }
         }
         
@@ -166,7 +166,7 @@ private extension SpotDetailViewController {
 extension SpotDetailViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return spotDetailViewModel.menuDummyData.count
+        return spotDetailViewModel.spotMenu.value?.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -83,8 +83,8 @@ extension SpotDetailViewModel {
     }
     
     // TODO: - 추후 PostGuidedSpotRequest 그냥 삭제?
-    func postGuidedSpot(spotID: Int64) {
-        ACService.shared.spotDetailService.postGuidedSpot(requestBody: PostGuidedSpotRequest(spotId: spotID)){ [weak self] response in
+    func postGuidedSpot() {
+        ACService.shared.spotDetailService.postGuidedSpot(requestBody: PostGuidedSpotRequest(spotId: self.spotID)){ [weak self] response in
             switch response {
             case .success(let data):
                 self?.onSuccessPostGuidedSpotRequest.value = true

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -11,21 +11,6 @@ import CoreLocation
 
 class SpotDetailViewModel {
     
-    let menuDummyData: [SpotMenuModel] = [
-        SpotMenuModel(menuID: 1, name: "마라탕", price: 10000, imageURL: ""),
-        SpotMenuModel(menuID: 1, name: "꿔바로우", price: 22000, imageURL: ""),
-        SpotMenuModel(menuID: 1, name: "마라탕", price: 10000, imageURL: ""),
-        SpotMenuModel(menuID: 1, name: "꿔바로우", price: 22000, imageURL: ""),
-        SpotMenuModel(menuID: 1, name: "마라탕", price: 10000, imageURL: ""),
-        SpotMenuModel(menuID: 1, name: "꿔바로우", price: 22000, imageURL: ""),
-        SpotMenuModel(menuID: 1, name: "마라탕", price: 10000, imageURL: ""),
-        SpotMenuModel(menuID: 1, name: "꿔바로우", price: 22000, imageURL: ""),
-        SpotMenuModel(menuID: 1, name: "마라탕", price: 10000, imageURL: ""),
-        SpotMenuModel(menuID: 1, name: "꿔바로우", price: 22000, imageURL: "")
-    ]
-    
-//    let spotDetailDummyData: SpotDetailInfoModel = SpotDetailInfoModel(spotID: 1, name: "아콘네 라면가게", spotType: "음식점", firstImageURL: "", openStatus: true, address: "서울시 마포구 동교동 27길 27", localAcornCount: 1, basicAcornCount: 1000, latitude: 37.556944, longitude: 126.923917)
-    
     let spotID: Int64
     
     let onSuccessGetSpotDetail: ObservablePattern<Bool> = ObservablePattern(nil)

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -32,6 +32,10 @@ class SpotDetailViewModel {
         
     var spotDetail: ObservablePattern<SpotDetailInfoModel> = ObservablePattern(nil)
     
+    let onSuccessGetSpotMenu: ObservablePattern<Bool> = ObservablePattern(nil)
+        
+    var spotMenu: ObservablePattern<[SpotMenuModel]> = ObservablePattern(nil)
+    
     init(spotID: Int64) {
         self.spotID = spotID
         ACLocationManager.shared.addDelegate(self)
@@ -71,6 +75,25 @@ extension SpotDetailViewModel {
         }
     }
     
+    func getSpotMenu() {
+        ACService.shared.spotDetailService.getSpotMenu(spotID: spotID) { [weak self] response in
+            switch response {
+            case .success(let data):
+                let spotMenuData = data.menuList.map { menu in
+                    return SpotMenuModel(menuID: menu.id,
+                                         name: menu.name,
+                                         price: menu.price,
+                                         imageURL: menu.image)
+                    }
+                    self?.spotMenu.value = spotMenuData
+                    self?.onSuccessGetSpotMenu.value = true
+            default:
+                print("VM - Failed To getSpotMenu")
+                self?.onSuccessGetSpotMenu.value = false
+                return
+            }
+        }
+    }
 }
 
 

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -117,7 +117,7 @@ extension SpotDetailViewModel: ACLocationManagerDelegate {
     func locationManager(_ manager: ACLocationManager, didUpdateLocation coordinate: CLLocationCoordinate2D) {
         guard let appName = Bundle.main.bundleIdentifier else { return }
         let sname = "내 위치"
-        let urlString = "nmap://route/walk?slat=\(coordinate.latitude)&slng=\(coordinate.longitude)&sname=\(sname)&dlat=\(String(describing: spotDetail.value?.latitude))&dlng=\(String(describing: spotDetail.value?.longitude))&dname=\(String(describing: spotDetail.value?.name))&appname=\(appName)"
+        let urlString = "nmap://route/walk?slat=\(coordinate.latitude)&slng=\(coordinate.longitude)&sname=\(sname)&dlat=\(spotDetail.value?.latitude ?? 0)&dlng=\(spotDetail.value?.longitude ?? 0)&dname=\(spotDetail.value?.name ?? "")&appname=\(appName)"
         guard let encodedStr = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
         
         guard let url = URL(string: encodedStr) else { return }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -34,8 +34,20 @@ class SpotDetailViewModel {
     deinit {
        ACLocationManager.shared.removeDelegate(self)
     }
+
+}
+
+// MARK: - 서버 통신 메소드
+
+extension SpotDetailViewModel {
     
-    // MARK: - 네이버지도 Redirect
+    
+}
+
+
+// MARK: - 네이버지도 Redirect
+
+extension SpotDetailViewModel {
     
     func redirectToNaverMap() {
         ACLocationManager.shared.checkUserDeviceLocationServiceAuthorization()
@@ -44,6 +56,8 @@ class SpotDetailViewModel {
     
 }
 
+
+// MARK: - 위치
 extension SpotDetailViewModel: ACLocationManagerDelegate {
     
     func locationManager(_ manager: ACLocationManager, didUpdateLocation coordinate: CLLocationCoordinate2D) {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotDetail/ViewModel/SpotDetailViewModel.swift
@@ -36,6 +36,8 @@ class SpotDetailViewModel {
         
     var spotMenu: ObservablePattern<[SpotMenuModel]> = ObservablePattern(nil)
     
+    let onSuccessPostGuidedSpotRequest: ObservablePattern<Bool> = ObservablePattern(nil)
+    
     init(spotID: Int64) {
         self.spotID = spotID
         ACLocationManager.shared.addDelegate(self)
@@ -94,6 +96,21 @@ extension SpotDetailViewModel {
             }
         }
     }
+    
+    // TODO: - 추후 PostGuidedSpotRequest 그냥 삭제?
+    func postGuidedSpot(spotID: Int64) {
+        ACService.shared.spotDetailService.postGuidedSpot(requestBody: PostGuidedSpotRequest(spotId: spotID)){ [weak self] response in
+            switch response {
+            case .success(let data):
+                self?.onSuccessPostGuidedSpotRequest.value = true
+            default:
+                print("VM - Failed To postGuidedSpot")
+                self?.onSuccessPostGuidedSpotRequest.value = false
+                return
+            }
+        }
+    }
+    
 }
 
 


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #85

## 🥔 **작업 내용**
장소 상세 페이지에서 호출하는 API들을 연결하였습니다.
- 장소 상세정보 조회
- 장소 메뉴 조회
- 최근 길 안내 장소 저장

## 🚨 참고 사항
지금 뷰 레이아웃이 이상한데 기디 측에 물어보고 확정한 후에 따로 이슈 파서 조정하겠습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰 14 Pro Max|<img src = "https://github.com/user-attachments/assets/ebe8d24c-c27f-47fe-b4ea-b91e73b7ec5d" width ="250">|



## 💥 To be sure
- [ ] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #85
