### PR TITLE
[FIX] 장소 리스트 2번째 셀이 사라지는 문제 해결 (#86)

### DIFF
--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotListItemSizeType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotListItemSizeType.swift
@@ -9,12 +9,14 @@ import Foundation
 
 enum SpotListItemSizeType {
     
-    case minimumLineSpacing, itemWidth, headerHeight
+    case minimumLineSpacing, itemWidth, longItemHeight, shortItemHeight, headerHeight
     
     var value: CGFloat {
         switch self {
         case .minimumLineSpacing: return 12
         case .itemWidth: return ScreenUtils.width - 40
+        case .longItemHeight: return 408
+        case .shortItemHeight: return 128
         case .headerHeight: return 38
         }
     }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotListItemSizeType.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/Type/SpotListItemSizeType.swift
@@ -15,8 +15,8 @@ enum SpotListItemSizeType {
         switch self {
         case .minimumLineSpacing: return 12
         case .itemWidth: return ScreenUtils.width - 40
-        case .longItemHeight: return 408
-        case .shortItemHeight: return 128
+        case .longItemHeight: return SpotListItemSizeType.itemWidth.value * 1.24
+        case .shortItemHeight: return SpotListItemSizeType.itemWidth.value * 0.39
         case .headerHeight: return 38
         }
     }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListView.swift
@@ -119,7 +119,7 @@ private extension SpotListView {
     
     func setCollectionView() {
         let flowLayout = UICollectionViewFlowLayout()
-        // NOTE: itemSize는 Controller에서 설정합니다. (collectionView의 height이 필요하기 때문)
+        // NOTE: itemSize는 Controller에서 설정합니다. (indexPath에 따라 다르기 때문)
         flowLayout.minimumLineSpacing = SpotListItemSizeType.minimumLineSpacing.value
         flowLayout.scrollDirection = .vertical
         

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -221,11 +221,7 @@ extension SpotListViewController: UICollectionViewDelegateFlowLayout {
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
         let itemWidth: CGFloat = SpotListItemSizeType.itemWidth.value
-        let collectionViewHeight: CGFloat = collectionView.frame.height
-        let shortHeight: CGFloat = shortItemHeight(collectionViewHeight)
-        let longHeight: CGFloat = longItemHeight(collectionViewHeight)
-        
-        let itemHeight = indexPath.item == 0 ? longHeight : shortHeight
+        let itemHeight: CGFloat = indexPath.row == 0 ? SpotListItemSizeType.longItemHeight.value : SpotListItemSizeType.shortItemHeight.value
         
         return CGSize(width: itemWidth, height: itemHeight)
     }
@@ -236,26 +232,6 @@ extension SpotListViewController: UICollectionViewDelegateFlowLayout {
         let itemWidth: CGFloat = SpotListItemSizeType.itemWidth.value
         let itemHeight: CGFloat = SpotListItemSizeType.headerHeight.value
         return CGSize(width: itemWidth, height: itemHeight)
-    }
-    
-}
-
-
-// MARK: - CollectionView ItemSize Method
-
-extension SpotListViewController {
-    
-    func longItemHeight(_ collectionViewHeight: CGFloat) -> CGFloat {
-        let lineSpacing = SpotListItemSizeType.minimumLineSpacing.value
-        let headerHeight = SpotListItemSizeType.headerHeight.value
-        let shortHeight = shortItemHeight(collectionViewHeight)
-        return collectionViewHeight - shortHeight - lineSpacing - headerHeight
-    }
-    
-    func shortItemHeight(_ collectionViewHeight: CGFloat) -> CGFloat {
-        let lineSpacing = SpotListItemSizeType.minimumLineSpacing.value
-        let headerHeight = SpotListItemSizeType.headerHeight.value
-        return (collectionViewHeight - lineSpacing * 3 - headerHeight) / 4
     }
     
 }


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #86 

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
컬렉션뷰 UI를 변경했을 때 item height 설정 로직도 수정했어야 했는데 그러지 않아서 생긴 문제였습니다.
모든 기기에서 item 비율이 유지되도록 height이 width에 대한 비율로 결정되도록 수정했습니다.

## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|
|아이폰 16 Pro|<img src = "https://github.com/user-attachments/assets/c547cfd5-eeaf-45bf-b240-ee42821b9e00" width ="250">|아이폰 se|<img src = "https://github.com/user-attachments/assets/ab477aa4-ad6c-4884-8a74-459feafcc908" width ="250">|


## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #86
