### PR TITLE
[FIX] 리프레시 컨트롤 안 보이는 문제 해결, 장소리스트 포스트 로직 변경, 탭바 문제 해결 (#127)

### DIFF
--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Component/CustomRefreshControl.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Component/CustomRefreshControl.swift
@@ -71,8 +71,9 @@ private extension CustomRefreshControl {
     
     func setLayout() {
         animationView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.size.equalTo(36)
+            $0.top.equalToSuperview().offset(60)
+            $0.centerX.equalToSuperview()
+            $0.size.equalTo(28)
         }
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -33,7 +33,6 @@ class SpotListViewController: BaseNavViewController {
         addTarget()
         
         viewModel.requestLocation()
-        viewModel.postSpotList()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -158,7 +157,7 @@ private extension SpotListViewController {
                 self.spotListView.collectionView.alpha = 0.5
             }) { _ in
                 
-                self.viewModel.postSpotList()
+                self.viewModel.requestLocation()
                 self.spotListView.hideSkeletonView(isHidden: false)
             }
         }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -248,14 +248,12 @@ private extension SpotListViewController {
     }
     
     func setRefreshControl() {
-        let control = CustomRefreshControl()
-        
-        control.addTarget(self,
-                          action: #selector(handleRefreshControl),
-                          for: .valueChanged
+        spotListView.collectionView.refreshControl = CustomRefreshControl()
+        spotListView.collectionView.refreshControl?.addTarget(
+            self,
+            action: #selector(handleRefreshControl),
+            for: .valueChanged
         )
-        
-        spotListView.collectionView.refreshControl = control
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -37,7 +37,7 @@ class SpotListViewController: BaseNavViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(false)
-
+        
         self.tabBarController?.tabBar.isHidden = false
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
@@ -115,6 +115,7 @@ extension SpotListViewModel: ACLocationManagerDelegate {
     func locationManager(_ manager: ACLocationManager,
                          didUpdateLocation coordinate: CLLocationCoordinate2D) {
         print("🛠️ coordinate: \(coordinate)")
+        
         userCoordinate = coordinate
         
         postSpotList()

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
@@ -18,8 +18,7 @@ class SpotListViewModel {
     
     var isUpdated: Bool = false
     
-    // TODO: userCoordinate 기본값 빼고 옵셔널로 만들기 (지금은 필터 설정했을 때 좌표가 0,0으로 찍히는 문제때문에 좌표 넣어둠...)
-    var userCoordinate: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 37.559171017384145, longitude: 126.9219534442884)
+    var userCoordinate: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 0, longitude: 0)
     
     
     // MARK: - Filter
@@ -65,7 +64,6 @@ class SpotListViewModel {
 extension SpotListViewModel {
     
     func postSpotList() {
-        print("🤍🤍🤍🤍spotType: \(spotType)")
         let requestBody = PostSpotListRequest(
             latitude: userCoordinate.latitude,
             longitude: userCoordinate.longitude,
@@ -105,10 +103,7 @@ extension SpotListViewModel {
                 return
             }
         }
-        // TODO: TimeOut 설정하기; 서버가 다운 된 경우 isSuccess가 set이 안돼서 무한 로딩됨
     }
-    
-    
     
 }
 
@@ -121,6 +116,8 @@ extension SpotListViewModel: ACLocationManagerDelegate {
                          didUpdateLocation coordinate: CLLocationCoordinate2D) {
         print("🛠️ coordinate: \(coordinate)")
         userCoordinate = coordinate
+        
+        postSpotList()
     }
     
 }

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
@@ -151,20 +151,21 @@ private extension SpotListFilterViewController {
         viewModel.restaurantPrice = self.restaurantPrice
         viewModel.cafePrice = self.cafePrice
         
-        viewModel.postSpotList()
+        viewModel.requestLocation()
         self.dismiss(animated: true)
     }
     
     @objc func didTapResetButton() {
-        self.viewModel.spotType.value = nil
-        self.viewModel.filterList = []
-        self.viewModel.spotCondition = SpotConditionModel(
+        viewModel.spotType.value = nil
+        viewModel.filterList = []
+        viewModel.spotCondition = SpotConditionModel(
             spotType: .restaurant,
             filterList: [],
             walkingTime: -1,
             priceRange: -1
         )
-        viewModel.postSpotList()
+        
+        viewModel.requestLocation()
         self.dismiss(animated: true)
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/TabBar/ACTabBarController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/TabBar/ACTabBarController.swift
@@ -17,11 +17,6 @@ class ACTabBarController: UITabBarController {
         super.viewDidLoad()
         
         delegate = self
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
         configureTabBarAppearance()
         setNavViewControllers()
     }
@@ -51,7 +46,6 @@ extension ACTabBarController {
         
         // NOTE: 글라스모피즘 뷰 얹기
         let glassView = GlassmorphismView()
-//        tabBar.backgroundImage? = UIImage(systemName: "photo") ?? UIImage()
         tabBar.addSubview(glassView)
         glassView.snp.makeConstraints {
             $0.edges.equalTo(tabBar)


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #127

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
- 장소 리스트가 탭 이동할 때는 변동되지 않고, 필터 또는 새로고침 시에만 변동되게 했습니다.
- 새로운 장소를 호출할 때마다 항상 현위치 갱신이 필요하기 때문에 post 메소드를 현위치 요청 메소드 안에 넣었습니다. 그리고 새 리스트가 필요할 때마다 현위치 요청 메소드를 호출했습니다.
- 탭바를 set하는 메소드들이 tabBarControl ViewWillAppear 부분에 있어서 업로드 탭을 갔다 올 때마다 탭바 인스턴스가 재생성되었고,
이 때문에 탭을 이동 시에 장소 리스트가 바뀌는 문제가 있었습니다.
-> viewDidLoad 에서 set하는 걸로 변경했습니다.

## 🚨 참고 사항
<!-- 참고사항을 적어주세요. -->
업로드 탭을 단순히 띄우는 걸로는 장소 리스트가 변하지 않는데,
장소를 탭할 때 requestLocation이 호출되면서 Delegate에 넣어둔 postSpotList 메소드가 호출돼용...
```
extension SpotListViewModel: ACLocationManagerDelegate {
    
    func locationManager(_ manager: ACLocationManager,
                         didUpdateLocation coordinate: CLLocationCoordinate2D) {
        print("🛠️ coordinate: \(coordinate)")
        
        userCoordinate = coordinate
        
        postSpotList()
    }
    
}
```


## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|:--:|:--:|
|아이폰 16 Pro|<img src = "" width ="250">|아이폰 13 mini|<img src = "" width ="250">|아이폰 se|<img src = "" width ="250">|

## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #127 
