### PR TITLE
[HOTFIX] 필터 초기화, 데이터 없을 때 노아콘뷰 보이게 수정, 취향일치율 hidden, 데이터 변경 없을 때 스켈레톤 hidden 풀기, DetailVC에 id 넘겨주기 (#138)

### DIFF
--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListCollectionViewCell.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/Cell/SpotListCollectionViewCell.swift
@@ -152,6 +152,8 @@ extension SpotListCollectionViewCell {
             let matchingRateStringSet = matchingRateHead + " " + String(matchingRate) + "%"
             matchingRateLabel.setLabel(text: matchingRateStringSet,
                                        style: .b4)
+        } else {
+            matchingRateView.isHidden = true
         }
         
         typeLabel.setLabel(text: spot.type.koreanText,

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListView.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListView.swift
@@ -45,8 +45,8 @@ class SpotListView: BaseView {
         
         self.addSubviews(
             collectionView,
-            noAcornView,
             skeletonView,
+            noAcornView,
             floatingButtonStack)
         
         floatingButtonStack.addArrangedSubviews(floatingLocationButton,
@@ -149,6 +149,7 @@ extension SpotListView {
     
     func hideNoAcornView(isHidden: Bool) {
         noAcornView.isHidden = isHidden
+        print("hidenoacornview :\(isHidden)")
     }
     
     func updateFilterButtonColor(_ isFilterSet: Bool) {

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -99,12 +99,15 @@ extension SpotListViewController {
                 if viewModel.isUpdated {
                     spotListView.collectionView.reloadData()
                     spotListView.hideSkeletonView(isHidden: true)
+                    spotListView.hideNoAcornView(isHidden: !viewModel.spotList.isEmpty)
                     print("🥑reloadData")
                 } else {
                     print("🥑데이터가 안 바뀌어서 리로드데이터 안 함")
+                    spotListView.hideNoAcornView(isHidden: !viewModel.spotList.isEmpty)
                 }
             } else {
                 print("🥑Post 실패")
+                spotListView.hideNoAcornView(isHidden: !viewModel.spotList.isEmpty)
             }
             
             viewModel.isUpdated = false

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -323,7 +323,7 @@ extension SpotListViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let item = viewModel.spotList[indexPath.item]
-        let vc = SpotDetailViewController(1) // TODO: 1 -> item.id로 변경
+        let vc = SpotDetailViewController(item.id)
         self.navigationController?.pushViewController(vc, animated: true)
     }
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/View/SpotListViewController.swift
@@ -113,7 +113,9 @@ extension SpotListViewController {
                     print("🥑reloadData")
                 } else {
                     print("🥑데이터가 안 바뀌어서 리로드데이터 안 함")
-                    spotListView.hideNoAcornView(isHidden: !viewModel.spotList.isEmpty)
+                    let dataExists = !viewModel.spotList.isEmpty
+                    spotListView.hideNoAcornView(isHidden: dataExists)
+                    spotListView.hideSkeletonView(isHidden: dataExists)
                 }
             } else {
                 print("🥑Post 실패")

--- a/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotList/ViewModel/SpotListViewModel.swift
@@ -33,13 +33,6 @@ class SpotListViewModel {
     
     var cafePrice: SpotType.CafePriceType = .fiveThousand
     
-    var spotCondition = SpotConditionModel(
-        spotType: .restaurant,
-        filterList: [],
-        walkingTime: -1,
-        priceRange: -1
-    )
-    
     
     // MARK: - Methods
     

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
@@ -126,10 +126,8 @@ private extension SpotListFilterViewController {
     
     @objc
     func didTapConductButton() {
-        guard let spotType = viewModel.spotType.value else {
-            viewModel.spotType.value = .restaurant
-            return // TODO: 인덱스 오류 해결
-        }
+        let spotType = viewModel.spotType.value ?? .restaurant
+        viewModel.filterList = []
         
         switch spotType {
         case .restaurant:

--- a/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
+++ b/ACON-iOS/ACON-iOS/Presentation/SpotListFilter/View/SpotListFilterViewController.swift
@@ -158,13 +158,6 @@ private extension SpotListFilterViewController {
     @objc func didTapResetButton() {
         viewModel.spotType.value = nil
         viewModel.filterList = []
-        viewModel.spotCondition = SpotConditionModel(
-            spotType: .restaurant,
-            filterList: [],
-            walkingTime: -1,
-            priceRange: -1
-        )
-        
         viewModel.requestLocation()
         self.dismiss(animated: true)
     }


### PR DESCRIPTION
# 🐿️ *Pull Requests* 

## 🪵 **작업 브랜치**
- #138

## 🥔 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
- 필터 새로 보낼 때마다 초기화
- 데이터 없을 때 노 아콘 뷰 보이게 수정

## 🚨 참고 사항
<!-- 참고사항을 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|:--:|:--:|
|아이폰 16 Pro|<img src = "" width ="250">|아이폰 13 mini|<img src = "" width ="250">|아이폰 se|<img src = "" width ="250">|

## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !

## 🌰 Resolve issue
- Resolved: #138
